### PR TITLE
Fix typo in Example section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ import (
 
 func main() {
 	router := gin.Default()
-	pprof.Register(router)
 	adminGroup := router.Group("/admin", func(c *gin.Context) {
 		if c.Request.Header.Get("Authorization") != "foobar" {
 			c.AbortWithStatus(http.StatusForbidden)


### PR DESCRIPTION
Fix typo in example, `pprof.Register()` is duplicate when using `pprof.RouteRegister()`.